### PR TITLE
Fix first sentence of transcript segment always missing

### DIFF
--- a/fileextractlib/VideoProcessor.py
+++ b/fileextractlib/VideoProcessor.py
@@ -120,7 +120,7 @@ class VideoProcessor:
                     sections.append(current_section)
                     current_section = VideoProcessor.Section(
                         start_time=vtt.captions[image_index].start_in_seconds,
-                        transcript=vtt.captions[image_index].text[2:0],
+                        transcript=vtt.captions[image_index].text[2:],
                         screen_text=screen_text,
                         embedding=None)
 


### PR DESCRIPTION
The transcript for segments always missed the first sentence of it. This PR fixes that.