### PR TITLE
Track AI processing status of entities & allow querying of it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Install torch manually, it needs a special version which supports our CUDA version. Install this AFTER the
 # requirements, as some of the requirements might install torch as well, but we want to install the correct version
-RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 
 # copy the current directory contents into the container at /app
 COPY . .

--- a/client/MediaServiceClient.py
+++ b/client/MediaServiceClient.py
@@ -7,7 +7,7 @@ import gql.transport.aiohttp
 class MediaServiceClient:
     def __init__(self):
         transport = gql.transport.aiohttp.AIOHTTPTransport(url=config.current["media_service_url"])
-        self._client = gql.Client(transport=transport, fetch_schema_from_transport=True)
+        self.__client = gql.Client(transport=transport, fetch_schema_from_transport=True)
 
     async def get_media_record_type_and_download_url(self, document_id: uuid.UUID) -> dict:
         query = gql.gql(
@@ -21,5 +21,18 @@ class MediaServiceClient:
             """
         )
         variables = {"recordId": str(document_id)}
-        result = await self._client.execute_async(query, variable_values=variables)
+        result = await self.__client.execute_async(query, variable_values=variables)
         return result["_internal_noauth_mediaRecordsByIds"][0]
+
+    async def get_media_record_ids_of_content(self, content_id: uuid.UUID) -> list[uuid.UUID]:
+        query = gql.gql(
+            """
+            query GetMediaRecordIdsOfContent($contentId: UUID!) {
+                _internal_noauth_mediaRecordsByContentIds(contentIds: [$contentId]) {
+                    id
+                }
+            }
+            """)
+        variables = {"contentId": str(content_id)}
+        result = await self.__client.execute_async(query, variable_values=variables)
+        return [x["id"] for x in result["_internal_noauth_mediaRecordsByContentIds"][0]]

--- a/controller/dapr_controller.py
+++ b/controller/dapr_controller.py
@@ -24,6 +24,5 @@ class DaprController:
         @dapr_app.subscribe(pubsub="meitrex", topic="content-media-record-links-set")
         def content_media_record_links_set_handler(data: dict):
             content_id = uuid.UUID(data["data"]["contentId"])
-            media_record_ids: list[uuid.UUID] = [uuid.UUID(id) for id in data["data"]["mediaRecordIds"]]
 
-            ai_service.enqueue_generate_content_media_record_links(content_id, media_record_ids)
+            ai_service.enqueue_generate_content_media_record_links(content_id)

--- a/dto/__init__.py
+++ b/dto/__init__.py
@@ -1,4 +1,4 @@
-from typing import NotRequired, TypedDict
+from typing import NotRequired, TypedDict, Optional
 from uuid import UUID
 
 from persistence.entities import *
@@ -31,3 +31,14 @@ class SemanticSearchResultDto(TypedDict):
 class MediaRecordSegmentLinkDto(TypedDict):
     segment1: VideoRecordSegmentDto | DocumentRecordSegmentDto
     segment2: VideoRecordSegmentDto | DocumentRecordSegmentDto
+
+class AiEntityProcessingStateDto(Enum):
+    UNKNOWN = auto()
+    ENQUEUED = auto()
+    PROCESSING = auto()
+    DONE = auto()
+
+class AiEntityProcessingProgressDto(TypedDict):
+    entityId: UUID
+    state: AiEntityProcessingStateDto
+    queuePosition: Optional[int]

--- a/persistence/entities.py
+++ b/persistence/entities.py
@@ -44,10 +44,20 @@ class SemanticSearchResultEntity:
         self.score = score
         self.media_record_segment_entity = media_record_segment_entity
 
+
 class IngestionStateDbType(Enum):
     ENQUEUED = auto()
+    PROCESSING = auto()
     DONE = auto()
+
 
 class IngestionEntityTypeDbType(Enum):
     MEDIA_RECORD = auto()
     CONTENT = auto()
+
+
+class EntityIngestionInfoEntity:
+    def __init__(self, entity_id: UUID, entity_type: IngestionEntityTypeDbType,ingestion_state: IngestionStateDbType):
+        self.entity_id = entity_id
+        self.entity_type = entity_type
+        self.ingestion_state = ingestion_state

--- a/persistence/entities.py
+++ b/persistence/entities.py
@@ -1,3 +1,4 @@
+from enum import Enum, auto
 from uuid import UUID
 from torch import Tensor
 
@@ -42,3 +43,11 @@ class SemanticSearchResultEntity:
     def __init__(self, score: float, media_record_segment_entity: VideoSegmentEntity | DocumentSegmentEntity):
         self.score = score
         self.media_record_segment_entity = media_record_segment_entity
+
+class IngestionStateDbType(Enum):
+    ENQUEUED = auto()
+    DONE = auto()
+
+class IngestionEntityTypeDbType(Enum):
+    MEDIA_RECORD = auto()
+    CONTENT = auto()

--- a/schema/mutation.graphqls
+++ b/schema/mutation.graphqls
@@ -20,7 +20,6 @@ type Mutation {
 
 input GenerateMediaRecordLinksInput {
     contentId: UUID!
-    mediaRecordIds: [UUID!]!
 }
 
 input IngestMediaRecordInput {

--- a/schema/query.graphqls
+++ b/schema/query.graphqls
@@ -74,6 +74,26 @@ type Query {
     any permissions check and should not be called without any validation of the caller's permissions. ⚠️
     """
     _internal_noauth_getMediaRecordSummary(mediaRecordId: UUID!): [String!]!
+
+    """
+    Gets the DocProcAI ingestion processing state of the specified media records. "UNKNOWN" is returned if the specified
+    ID is unknown to the service (either because a media record with the given ID does not exist or because the media
+    record has not yet ever been enqueued into the service's processing system).
+
+    ⚠️ This query is only accessible internally in the system and allows the caller to fetch contents without
+    any permissions check and should not be called without any validation of the caller's permissions. ⚠️
+    """
+    _internal_noauth_getMediaRecordsAiProcessingProgress(mediaRecordIds: [UUID!]!): [AiEntityProcessingProgress!]!
+
+    """
+    Gets the DocProcAI ingestion processing state of the contents with the specified IDs. "UNKNOWN" is returned if the
+    specified ID is unknown to the service (either because a content with the given ID does not exist or because
+    the content has not yet ever been enqueued into the service's processing system).
+
+    ⚠️ This query is only accessible internally in the system and allows the caller to fetch contents without
+    any permissions check and should not be called without any validation of the caller's permissions. ⚠️
+    """
+    _internal_noauth_getContentsAiProcessingProgress(contentIds: [UUID!]!): [AiEntityProcessingProgress!]!
 }
 
 type MediaRecordSegmentLink {
@@ -166,3 +186,15 @@ type VideoRecordSegment implements MediaRecordSegment {
     title: String
 }
 
+type AiEntityProcessingProgress {
+    entityId: UUID!
+    state: AiEntityProcessingState!
+    queuePosition: Int
+}
+
+enum AiEntityProcessingState {
+    UNKNOWN,
+    ENQUEUED,
+    PROCESSING,
+    DONE
+}

--- a/service/DocProcAiService.py
+++ b/service/DocProcAiService.py
@@ -87,7 +87,7 @@ class DocProcAiService:
                     # generate and store a summary of this media record
                     self.__lecture_llm_generator.generate_summary_for_document(document_data)
 
-                self.database.insert_media_record(media_record_id, document_data.summary)
+                self.database.insert_media_record(media_record_id, document_data.summary, None)
             elif record_type == "VIDEO":
                 video_processor = VideoProcessor(
                     segment_image_similarity_threshold=
@@ -95,9 +95,6 @@ class DocProcAiService:
                     minimum_segment_length=config.current["video_segmentation"]["minimum_segment_length"])
                 video_data = video_processor.process(download_url)
                 del video_processor
-
-                # store the captions of the video
-                self.database.insert_video_captions(media_record_id, video_data.vtt.content)
 
                 # generate text embeddings for the segments of the video
                 self.__lecture_video_embedding_generator.generate_embeddings(video_data.segments)
@@ -122,7 +119,8 @@ class DocProcAiService:
                     # generate and store a summary of this media record
                     self.__lecture_llm_generator.generate_summary_for_video(video_data)
 
-                self.database.insert_media_record(media_record_id, video_data.summary)
+                # store media record-level data: summary & closed captions vtt string
+                self.database.insert_media_record(media_record_id, video_data.summary, video_data.vtt.content)
             else:
                 raise ValueError("Asked to ingest unsupported media record type of type " + media_record["type"])
 

--- a/utils/SortedPriorityQueue.py
+++ b/utils/SortedPriorityQueue.py
@@ -1,0 +1,51 @@
+from typing import Generic, TypeVar, Callable
+
+T = TypeVar("T")
+
+class SortedPriorityQueue(Generic[T]):
+    """
+    A priority queue which is backed by a sorted list which is re-sorted each time an element is inserted, compared
+    to the "regular" python priority queue which is backed by a heap.
+    This queue is slower, but has the advantage that a definitive position in the queue can be assigned to each item
+    (although that position in the queue might increase if another item with a higher priority is enqueued).
+    Priority is determined through the items' sort order, where an item being LESS THAN another equals a HIGHER priority
+    to the SMALLER item.
+    """
+
+    def __init__(self):
+        self.__items: list[T] = []
+
+    def put(self, item: T) -> None:
+        """
+        Enqueue an item into the queue.
+        :param item: The item to enqueue.
+        :return: Nothing
+        """
+        self.__items.append(item)
+        self.__items.sort()
+
+    def __len__(self) -> int:
+        """
+        :return: Number of items in the queue.
+        """
+        return len(self.__items)
+
+    def first_index_satisfying_predicate(self, predicate: Callable[[T], bool]):
+        """
+        Returns the index of the first (i.e. highest-priority)
+        :param predicate: Function to which the item is passed. If the function evaluates to true for an item, this
+        item's index is returned.
+        :return: Returns the index of the first (i.e. highest-priority) item in the queue matching the predicate.
+        :raise: ValueError If no item matching predicate could be found in the queue.
+        """
+        try:
+            return self.__items.index(next(x for x in self.__items if predicate(x)))
+        except StopIteration:
+            raise ValueError("No item matching predicate could be found in the queue.")
+
+    def get(self) -> T:
+        """
+        Dequeues (i.e. removes) the highest-priority item from the queue and returns item.
+        :return: The highest-priority item in the queue.
+        """
+        return self.__items.pop(0)


### PR DESCRIPTION
* Processing status of media records & contents is now tracked via DB
* If the service crashes with entities being processed or with entities in the processing queue, then at restart the processing is resumed
* Allow querying of processing state (enqueued, currently processing, processing done) & position in the queue for entities