### PR TITLE
Change /embed query to POST & Publish MediaRecordInfoEvent

### DIFF
--- a/controller/dapr_controller.py
+++ b/controller/dapr_controller.py
@@ -1,6 +1,3 @@
-from enum import Enum, auto
-
-import dapr
 from dapr.ext.fastapi.app import DaprApp
 from fastapi import FastAPI
 import uuid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - "9901:9901"
     depends_on:
       - database
+    environment:
+      - DAPR_HTTP_PORT=9900
   dapr-docprocai:
     image: "daprio/daprd"
     command: [

--- a/events/DaprPublisher.py
+++ b/events/DaprPublisher.py
@@ -1,0 +1,17 @@
+import requests
+import json
+
+from events import MediaRecordInfoEvent
+
+PUBSUB_NAME = "meitrex"
+
+class DaprPublisher:
+    def __init__(self, dapr_port=9900):
+        self.base_url = f"http://localhost:{dapr_port}/v1.0"
+
+    def publish_media_record_info_event(self, event: MediaRecordInfoEvent):
+        topic = "media-record-info"
+        url = f"{self.base_url}/publish/{PUBSUB_NAME}/{topic}"
+        resp = requests.post(url, json=json.dumps(event))
+        resp.raise_for_status()
+        return resp.json() if resp.content else None

--- a/events/DaprPublisher.py
+++ b/events/DaprPublisher.py
@@ -1,12 +1,14 @@
 import requests
 import json
+import os
 
 from events import MediaRecordInfoEvent
 
 PUBSUB_NAME = "meitrex"
 
 class DaprPublisher:
-    def __init__(self, dapr_port=9900):
+    def __init__(self):
+        dapr_port = os.environ.get("DAPR_HTTP_PORT", "3500")
         self.base_url = f"http://localhost:{dapr_port}/v1.0"
 
     def publish_media_record_info_event(self, event: MediaRecordInfoEvent):

--- a/events/MediaRecordInfoEvent.py
+++ b/events/MediaRecordInfoEvent.py
@@ -1,0 +1,6 @@
+from typing import Optional, TypedDict
+
+class MediaRecordInfoEvent(TypedDict):
+    mediaRecordId: str
+    durationSeconds: Optional[float]
+    pageCount: Optional[int]

--- a/events/MediaRecordInfoEvent.py
+++ b/events/MediaRecordInfoEvent.py
@@ -2,5 +2,6 @@ from typing import Optional, TypedDict
 
 class MediaRecordInfoEvent(TypedDict):
     mediaRecordId: str
+    mediaType: str
     durationSeconds: Optional[float]
     pageCount: Optional[int]

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -1,0 +1,2 @@
+from events.DaprPublisher import DaprPublisher
+from events.MediaRecordInfoEvent import MediaRecordInfoEvent

--- a/fileextractlib/LLMService.py
+++ b/fileextractlib/LLMService.py
@@ -209,8 +209,10 @@ class DefaultLLMService(AbstractLLMService):
 
     def _fetch_candidate_model_list(self, profile: LLMProfile) -> List[str]:
         model_list: List[Dict] = self._fetch_available_models()
+        print("All available models:", model_list)
         model_filter: Callable[[List[Dict]], List[Dict]] = DefaultLLMService.create_model_filter(profile)
         candidate_model_list: List[Dict] = model_filter(model_list)
+        print("Candidate models: ", candidate_model_list)
         candidate_model_name_list: List[str] = DefaultLLMService.extract_model_names(candidate_model_list)
         return candidate_model_name_list
 

--- a/fileextractlib/SentenceEmbeddingRunner.py
+++ b/fileextractlib/SentenceEmbeddingRunner.py
@@ -14,10 +14,8 @@ class SentenceEmbeddingRunner:
         self.hostname = config.current["text_embedding"]["hostname"]
         self.port = config.current["text_embedding"]["port"]
 
-    def _create_url(self, words: List[str]) -> str:
-        query_params = [("words", word) for word in words]
-        query_string = urllib.parse.urlencode(query_params)
-        return f"{self.protocol}://{self.hostname}:{self.port}/embed?{query_string}"
+    def _create_url(self) -> str:
+        return f"{self.protocol}://{self.hostname}:{self.port}/embed"
 
     def generate_embeddings(self, words: List[str]) -> NDArray[np.float64]:
         """
@@ -25,7 +23,12 @@ class SentenceEmbeddingRunner:
         :param words: a list of words for which the respective embeddings shall be computed.
         :return: a list of embeddings vectors.
         """
-        response = requests.get(self._create_url(words))
+        response = requests.post(
+            self._create_url(),
+            json={
+                "words": words,
+            }
+        )
         response.raise_for_status()
         return np.array(response.json())
 

--- a/fileextractlib/VideoData.py
+++ b/fileextractlib/VideoData.py
@@ -30,9 +30,14 @@ class VideoData:
     Represents a video's data, containing the captions and the sections of the video.
     """
 
-    def __init__(self, vtt: WebVTT, segments: list[VideoSegmentData], summary: Optional[list[str]] = None):
+    def __init__(self,
+                 length_seconds: float,
+                 vtt: WebVTT,
+                 segments: list[VideoSegmentData],
+                 summary: Optional[list[str]] = None):
         if summary is None:
             summary = []
+        self.length_seconds: float = length_seconds
         self.vtt: WebVTT = vtt
         self.segments: list[VideoSegmentData] = segments
         self.summary: list[str] = summary

--- a/fileextractlib/VideoProcessor.py
+++ b/fileextractlib/VideoProcessor.py
@@ -40,6 +40,9 @@ class VideoProcessor:
         transcript_generator: TranscriptGenerator = TranscriptGenerator()
         vtt: WebVTT = transcript_generator.process_to_vtt(file_url)
 
+        json_probe = ffmpeg.probe(file_url)
+        length_seconds = float(json_probe["format"]["duration"])
+
         stream = ffmpeg.input(file_url)
 
         # construct ffmpeg select filter to extract a frame at each transcript caption start time
@@ -170,7 +173,7 @@ class VideoProcessor:
         current_segment.thumbnail = current_segment_image
         segments.append(current_segment)
 
-        video_data = VideoData(vtt, segments)
+        video_data = VideoData(length_seconds, vtt, segments)
 
         _logger.info("Segmented video in " + str(time.time() - start_time) + " seconds.")
 

--- a/service/DocProcAiService.py
+++ b/service/DocProcAiService.py
@@ -107,6 +107,16 @@ class DocProcAiService:
                     _logger.info("Starting document processor for " + str(media_record_id))
                     document_processor = DocumentProcessor()
                     document_data = document_processor.process(download_url)
+
+                    # publish document info event
+                    dapr_publisher = DaprPublisher()
+                    dapr_publisher.publish_media_record_info_event({
+                        "mediaRecordId": str(media_record_id),
+                        "mediaType": record_type,
+                        "durationSeconds": None,
+                        "pageCount": len(document_data.pages)
+                    })
+
                     _logger.info("Generating embeddings for " + str(media_record_id))
                     self.__lecture_pdf_embedding_generator.generate_embeddings(document_data.pages)
                     for segment in document_data.pages:
@@ -138,10 +148,10 @@ class DocProcAiService:
                     dapr_publisher = DaprPublisher()
                     dapr_publisher.publish_media_record_info_event({
                         "mediaRecordId": str(media_record_id),
+                        "mediaType": record_type,
                         "durationSeconds": video_data.length_seconds,
                         "pageCount": None
                     })
-
 
                     # generate text embeddings for the segments of the video
                     _logger.info("Generating embeddings for " + str(media_record_id))


### PR DESCRIPTION
* the service now publishes the MediaRecordInfoEvent during processing of the files to notify other services of video length/pdf page count
* /embed query to NLP-service is now a POST request to prevent errors when prompt is too long