### PR TITLE
Skip Unsupported Media Records during Ingestion & Improve Dapr Logging

### DIFF
--- a/events/DaprPublisher.py
+++ b/events/DaprPublisher.py
@@ -1,10 +1,13 @@
 import requests
-import json
+import logging
 import os
+import json
 
 from events import MediaRecordInfoEvent
 
 PUBSUB_NAME = "meitrex"
+
+_logger = logging.getLogger(__name__)
 
 class DaprPublisher:
     def __init__(self):
@@ -16,4 +19,5 @@ class DaprPublisher:
         url = f"{self.base_url}/publish/{PUBSUB_NAME}/{topic}"
         resp = requests.post(url, json=event)
         resp.raise_for_status()
+        _logger.info("Published event: %s", json.dumps(event))
         return resp.json() if resp.content else None

--- a/service/DocProcAiService.py
+++ b/service/DocProcAiService.py
@@ -180,7 +180,8 @@ class DocProcAiService:
                                                                              video_data.summary,
                                                                              video_data.vtt.content)
                 else:
-                    raise ValueError("Asked to ingest unsupported media record type of type " + media_record["type"])
+                    _logger.info("Asked to ingest unsupported media record type of type " + media_record["type"] +
+                                 ". Skipping.")
 
                 try:
                     self.__generate_tags()


### PR DESCRIPTION
* Previously, receiving an unsupported media record type to ingest caused the docprocai service to raise an exception. As the media record was part of the ingestion queue, this exception repeated ad infinitum. Now, unsupported media records are skipped, (the event being logged at INFO level) their processing status set to DONE so the docprocai service does not further care about them
* Adds a INFO-level logging message when a Dapr event is published